### PR TITLE
[Bug] 페이지 이동시 Header가 재렌더링 되면서 이벤트리스너가 중복으로 부착되던 현상 수정, Header 컴포넌트 i…

### DIFF
--- a/web/src/components/ContentTitle.js
+++ b/web/src/components/ContentTitle.js
@@ -12,17 +12,6 @@ class ContentTitle extends Component {
         </div>
     `;
   }
-
-  setEvent() {
-    this.addEvent("click", ".menu_name", (e) => {
-      const $menu = e.target.id;
-      if ($menu === "menu_home") {
-        navigate("/web/");
-      } else if ($menu === "menu_signup") {
-        navigate("/web/signup");
-      }
-    });
-  }
 }
 
 export default ContentTitle;

--- a/web/src/components/Header.js
+++ b/web/src/components/Header.js
@@ -4,12 +4,12 @@ class Header extends Component {
   template() {
     return `
         <header>
-        <div class="header header_left">
-            <span class="menu_name" id="menu_home">HOME</span>
-        </div>
-        <div class="header header_right">
-            <span class="menu_name" id="menu_signup">SIGNUP</span>
-        </div>
+          <div class="header header_left">
+              <span class="menu_name" id="menu_home">HOME</span>
+          </div>
+          <div class="header header_right">
+              <span class="menu_name" id="menu_signup">SIGNUP</span>
+          </div>
         </header>
     `;
   }

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -14,7 +14,9 @@ const routes = [
 ];
 
 const App = async () => {
-  new Header(document.querySelector(".app"));
+  if (!document.querySelector("header")) {
+    new Header(document.querySelector(".app"));
+  }
 
   const main = document.createElement("main");
   main.id = "page_content";
@@ -28,7 +30,6 @@ const App = async () => {
   });
 
   let match = pageMatches.find((pageMatch) => pageMatch.isMatch);
-  console.log(match);
   new match.route.view(document.querySelector("#page_content"));
 };
 


### PR DESCRIPTION
1. 페이지 이동 시에 Header 컴포넌트가 계속 재랜더링 되면서 이벤트 핸들러도 중복해서 부착되던 현상 수정
2. Header 컴포넌트는 초기 1회만 렌더링 되도록 수정
3. ContentTitle 컴포넌트는 라우팅 관련 setEvent 로직이 필요하지 않으므로 메서드 삭제.
4. Header 컴포넌트 Template indent 수정